### PR TITLE
Switch to zeropool bn library and make `hash_to_try_and_increment` visible outside crate 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/sedaprotocol/bn254"
 readme = "README.md"
 
 [dependencies]
-bn = { package = "substrate-bn", version = "0.6" }
+bn = { package = "zeropool-bn", version = "0.5.11", features = [] }
 byteorder = "1.4"
 rand = { version = "0.8", default-features = false }
 sha2 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/sedaprotocol/bn254"
 readme = "README.md"
 
 [dependencies]
-bn = { package = "zeropool-bn", version = "0.5.11", features = [] }
+bn = { package = "zeropool-bn", features = [] }
 byteorder = "1.4"
 rand = { version = "0.8", default-features = false }
 sha2 = "0.10"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -26,7 +26,7 @@ pub(crate) const LAST_MULTIPLE_OF_FQ_MODULUS_LOWER_THAN_2_256: arith::U256 = ari
 /// # Returns
 ///
 /// * If successful, a point in the [G1] group representing the hashed point.
-pub(crate) fn hash_to_try_and_increment<T: AsRef<[u8]>>(message: T) -> Result<G1> {
+pub fn hash_to_try_and_increment<T: AsRef<[u8]>>(message: T) -> Result<G1> {
     // Add counter suffix
     // This message should be: ciphersuite || 0x01 || message || ctr
     // For the moment we work with message || ctr until a tag is decided

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,3 +55,4 @@ mod test {
 pub use ecdsa::{check_public_keys, ECDSA};
 pub use error::{Error, Result};
 pub use types::{PrivateKey, PublicKey, PublicKeyG1, Signature};
+pub use hash::hash_to_try_and_increment;


### PR DESCRIPTION
These two changes allow the mainchain contract to:
- removed duplicated function `hash_to_try_and_increment`
- serialize group types to pass to the NEAR precompile function `alt_bn128_pairing_check`