### PR TITLE
feat: create `format_pairing_check_values` helper function for NEAR precompile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [dependencies]
 bn = { package = "zeropool-bn", features = [] }
 byteorder = "1.4"
+near-sdk = { version = "4.1.1", features = [] }
 rand = { version = "0.8", default-features = false }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     PointInJacobian,
     #[error("Bn254 verification failed")]
     VerificationFailed,
+    #[error("Serialization failed")]
+    SerializationError,
 }
 
 impl From<CurveError> for Error {
@@ -54,6 +56,18 @@ impl From<GroupError> for Error {
 impl From<bn::arith::Error> for Error {
     fn from(_error: bn::arith::Error) -> Self {
         Error::InvalidLength
+    }
+}
+
+impl From<std::vec::Vec<u8>> for Error {
+    fn from(_error: std::vec::Vec<u8>) -> Self {
+        Error::SerializationError
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(_error: std::io::Error) -> Self {
+        Error::SerializationError
     }
 }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -26,7 +26,7 @@ pub(crate) const LAST_MULTIPLE_OF_FQ_MODULUS_LOWER_THAN_2_256: arith::U256 = ari
 /// # Returns
 ///
 /// * If successful, a point in the [G1] group representing the hashed point.
-pub fn hash_to_try_and_increment<T: AsRef<[u8]>>(message: T) -> Result<G1> {
+pub(crate) fn hash_to_try_and_increment<T: AsRef<[u8]>>(message: T) -> Result<G1> {
     // Add counter suffix
     // This message should be: ciphersuite || 0x01 || message || ctr
     // For the moment we work with message || ctr until a tag is decided

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,4 +55,4 @@ mod test {
 pub use ecdsa::{check_public_keys, ECDSA};
 pub use error::{Error, Result};
 pub use types::{PrivateKey, PublicKey, PublicKeyG1, Signature};
-pub use hash::hash_to_try_and_increment;
+pub use utils::format_pairing_check_values;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,18 @@
 use bn::{
     arith::{U256, U512},
+    G1,
+    G2,
     *,
 };
 use byteorder::ByteOrder;
+use near_sdk::borsh::BorshSerialize;
 
-use crate::error::{Error, Result};
+use crate::{
+    error::{Error, Result},
+    hash::hash_to_try_and_increment,
+    PublicKey,
+    Signature,
+};
 
 /// Function to calculate the modulus of a [U256].
 ///
@@ -183,4 +191,23 @@ pub(crate) fn g1_to_uncompressed(g1: G1) -> Result<Vec<u8>> {
     Fq::into_u256(affine_coords.y()).to_big_endian(&mut result[32..64])?;
 
     Ok(result.to_vec())
+}
+
+pub fn format_pairing_check_values(
+    message: Vec<u8>,
+    signature: Vec<u8>,
+    public_key: Vec<u8>,
+) -> [([u8; 64], [u8; 128]); 2] {
+    // First pairing input: e(Uncompressed H(m) on G1, Uncompressed PubKey on G2)
+    let msg_hash_point = hash_to_try_and_increment(message).unwrap();
+    let msg_hash_arr: [u8; 64] = msg_hash_point.try_to_vec().unwrap().try_into().unwrap();
+    let pk_point = PublicKey::from_compressed(&public_key).unwrap();
+    let pk_arr: [u8; 128] = pk_point.0.try_to_vec().unwrap().try_into().unwrap();
+
+    // Second pairing input:  e(Uncompressed Signature on G1,-G2::one())
+    let sig_point = Signature::from_compressed(&signature).unwrap();
+    let sig_arr: [u8; 64] = sig_point.0.try_to_vec().unwrap().try_into().unwrap();
+    let n_g2: [u8; 128] = (-G2::one()).try_to_vec().unwrap().try_into().unwrap();
+
+    [(msg_hash_arr, pk_arr), (sig_arr, n_g2)]
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -193,21 +193,22 @@ pub(crate) fn g1_to_uncompressed(g1: G1) -> Result<Vec<u8>> {
     Ok(result.to_vec())
 }
 
+/// Function to format the inputs using Borsh for a pairing check
 pub fn format_pairing_check_values(
     message: Vec<u8>,
     signature: Vec<u8>,
     public_key: Vec<u8>,
-) -> [([u8; 64], [u8; 128]); 2] {
+) -> Result<[([u8; 64], [u8; 128]); 2]> {
     // First pairing input: e(Uncompressed H(m) on G1, Uncompressed PubKey on G2)
-    let msg_hash_point = hash_to_try_and_increment(message).unwrap();
-    let msg_hash_arr: [u8; 64] = msg_hash_point.try_to_vec().unwrap().try_into().unwrap();
-    let pk_point = PublicKey::from_compressed(&public_key).unwrap();
-    let pk_arr: [u8; 128] = pk_point.0.try_to_vec().unwrap().try_into().unwrap();
+    let msg_hash_point = hash_to_try_and_increment(message)?;
+    let msg_hash_arr: [u8; 64] = msg_hash_point.try_to_vec()?.try_into()?;
+    let pk_point = PublicKey::from_compressed(public_key)?;
+    let pk_arr: [u8; 128] = pk_point.0.try_to_vec()?.try_into()?;
 
     // Second pairing input:  e(Uncompressed Signature on G1,-G2::one())
-    let sig_point = Signature::from_compressed(&signature).unwrap();
-    let sig_arr: [u8; 64] = sig_point.0.try_to_vec().unwrap().try_into().unwrap();
-    let n_g2: [u8; 128] = (-G2::one()).try_to_vec().unwrap().try_into().unwrap();
+    let sig_point = Signature::from_compressed(signature)?;
+    let sig_arr: [u8; 64] = sig_point.0.try_to_vec()?.try_into()?;
+    let n_g2: [u8; 128] = (-G2::one()).try_to_vec()?.try_into()?;
 
-    [(msg_hash_arr, pk_arr), (sig_arr, n_g2)]
+    Ok([(msg_hash_arr, pk_arr), (sig_arr, n_g2)])
 }


### PR DESCRIPTION
This PR allows the mainchain contract to remove the bn dependency by moving the input formatting logic to this package instead