### PR TITLE
fix: use BorshSerialize from `borsh` crate

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,67 @@
+name: Push
+on:
+  pull_request:
+    push:
+      branches:
+        - main
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Fmt Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust Nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: rustfmt
+
+      - name: Format Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+clippy_and_test:
+    name: Clippy and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust Stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Clippy Check
+        env:
+          RUSTFLAGS: '-D warnings'
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features
+
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 bn = { package = "zeropool-bn", features = [] }
+borsh = "0.9"
 byteorder = "1.4"
-near-sdk = { version = "4.1.1", features = [] }
 rand = { version = "0.8", default-features = false }
 sha2 = "0.10"
 thiserror = "1.0"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,8 @@ use bn::{
     G2,
     *,
 };
+use borsh::BorshSerialize;
 use byteorder::ByteOrder;
-use near_sdk::borsh::BorshSerialize;
 
 use crate::{
     error::{Error, Result},


### PR DESCRIPTION
This PR simply replaces the dependency on `near_sdk` with `borsh` crate.
It also adds a simple Github Actions workflow. :) 