### PR TITLE
feat: add format_pairing_check_uncompressed_values()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,4 +60,4 @@ mod test {
 pub use ecdsa::{check_public_keys, ECDSA};
 pub use error::{Error, Result};
 pub use types::{PrivateKey, PublicKey, PublicKeyG1, Signature};
-pub use utils::format_pairing_check_values;
+pub use utils::{format_pairing_check_uncompressed_values, format_pairing_check_values};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -219,10 +219,10 @@ pub fn format_pairing_check_uncompressed_values(
     mut public_key: Vec<u8>,
 ) -> Result<[([u8; 64], [u8; 128]); 2]> {
     // convert to little endian
-    for i in [0, 32] {
+    for i in (0..=32).step_by(32) {
         signature[i..i + 32].reverse()
     }
-    for i in [0, 32, 64, 96] {
+    for i in (0..=96).step_by(32) {
         public_key[i..i + 32].reverse()
     }
 


### PR DESCRIPTION
Adds a utility function `format_pairing_check_uncompressed_values` that formats uncompressed big-endian signatures and public keys to slices of little-endian bytes.